### PR TITLE
Update getExpr to account for an elif comment block

### DIFF
--- a/src/get-expr.ts
+++ b/src/get-expr.ts
@@ -68,6 +68,24 @@ const skipBracket = (expr: string, start: number, stack: string[]) => {
 }
 
 /**
+ * Handles the extraction of an expression with a comment block slash or regular
+ * comment slash.
+ *
+ * @param expr Raw expression
+ * @param index Position of this slash
+ */
+function handleSlashExtraction (expr: string, index: number) {
+  if (expr[index + 1] === '/') {
+    return expr.slice(0, index)
+  }
+
+  if (expr[index - 1] === '*') {
+    return expr.slice(0, index - 1)
+  }
+  return null
+}
+
+/**
  * To find the comment (//), it is necessary to skip strings, es6 tl,
  * brackets, and regexes
  */
@@ -99,8 +117,9 @@ const extractExpr = function (expr: string, start: number) {
         re.lastIndex = skipES6TL(expr, mm.index, stack)
         break
       case '/':
-        if (expr[mm.index + 1] === '/') {
-          return expr.slice(0, mm.index)
+        const result = handleSlashExtraction(expr, mm.index)
+        if (result) {
+          return result
         }
         re.lastIndex = skipRegex(expr, mm.index)
     }

--- a/src/get-expr.ts
+++ b/src/get-expr.ts
@@ -123,7 +123,7 @@ const getExpr = function (key: string, expr: string) {
   }
 
   if (expr.indexOf('*/') > 0) {
-    return expr.slice(0, expr.indexOf('*/')).trim();
+    return expr.slice(0, expr.indexOf('*/')).trim()
   }
 
   /*

--- a/src/get-expr.ts
+++ b/src/get-expr.ts
@@ -141,10 +141,6 @@ const getExpr = function (key: string, expr: string) {
     return expr.trim()
   }
 
-  if (expr.indexOf('*/') > 0) {
-    return expr.slice(0, expr.indexOf('*/')).trim()
-  }
-
   /*
     When an assignment has a regex (ex: `#set _R /\s/`), skipRegex will not
     recognize it due to invalid syntax. Inserting the missing '=' solves this.

--- a/src/get-expr.ts
+++ b/src/get-expr.ts
@@ -122,6 +122,10 @@ const getExpr = function (key: string, expr: string) {
     return expr.trim()
   }
 
+  if (expr.indexOf('*/') > 0) {
+    return expr.slice(0, expr.indexOf('*/')).trim();
+  }
+
   /*
     When an assignment has a regex (ex: `#set _R /\s/`), skipRegex will not
     recognize it due to invalid syntax. Inserting the missing '=' solves this.

--- a/src/get-expr.ts
+++ b/src/get-expr.ts
@@ -74,7 +74,7 @@ const skipBracket = (expr: string, start: number, stack: string[]) => {
  * @param expr Raw expression
  * @param index Position of this slash
  */
-function handleSlashExtraction (expr: string, index: number) {
+const handleSlashExtraction = function (expr: string, index: number) {
   if (expr[index + 1] === '/') {
     return expr.slice(0, index)
   }


### PR DESCRIPTION
This will fix the problem with using #elif as a comment block, like `// #elif _CONDITION */` where the `*/` would crash the parser.